### PR TITLE
Align crypto_generichash state to 64 byte boundary

### DIFF
--- a/pysodium/__init__.py
+++ b/pysodium/__init__.py
@@ -53,17 +53,18 @@ crypto_scalarmult_BYTES = 32L
 crypto_sign_BYTES = 64L
 
 """
-typedef struct crypto_generichash_blake2b_state {
+#pragma pack(push, 1)
+CRYPTO_ALIGN(64) typedef struct crypto_generichash_blake2b_state {
     uint64_t h[8];
     uint64_t t[2];
     uint64_t f[2];
-    uint8_t  buf[256];
+    uint8_t  buf[2 * 128];
     size_t   buflen;
     uint8_t  last_node;
-    ...;
-} crypto_generichash_state;
+} crypto_generichash_blake2b_state;
+#pragma pack(pop)
 """
-crypto_generichash_state = 8*12 + 256 + ctypes.sizeof(ctypes.c_size_t) + 1
+crypto_generichash_state = 8*12 + 256 + ctypes.sizeof(ctypes.c_size_t) + 1 + 63
 
 def crypto_scalarmult_curve25519(n,p):
     buf = ctypes.create_string_buffer(crypto_scalarmult_BYTES)
@@ -85,19 +86,25 @@ def crypto_generichash(m, k=b'', outlen=crypto_generichash_BYTES):
 
 #crypto_generichash_init(crypto_generichash_state *state, const unsigned char *key, const size_t keylen, const size_t outlen);
 def crypto_generichash_init(outlen=crypto_generichash_BYTES, k=b''):
-    buf = ctypes.create_string_buffer(crypto_generichash_state)
-    sodium.crypto_generichash_init(buf, k, ctypes.c_ulonglong(len(k)), outlen)
-    return buf.raw
+    state = ctypes.create_string_buffer(crypto_generichash_state)
+    statealign = ctypes.addressof(state) + 63
+    statealign ^= statealign & 63
+    sodium.crypto_generichash_init(statealign, k, ctypes.c_ulonglong(len(k)), outlen)
+    return state
 
 #crypto_generichash_update(crypto_generichash_state *state, const unsigned char *in, unsigned long long inlen);
 def crypto_generichash_update(state, m):
-    sodium.crypto_generichash_update(state, m, ctypes.c_ulonglong(len(m)))
+    statealign = ctypes.addressof(state) + 63
+    statealign ^= statealign & 63
+    sodium.crypto_generichash_update(statealign, m, ctypes.c_ulonglong(len(m)))
     return state
 
 #crypto_generichash_final(crypto_generichash_state *state, unsigned char *out, const size_t outlen);
 def crypto_generichash_final(state, outlen=crypto_generichash_BYTES):
+    statealign = ctypes.addressof(state) + 63
+    statealign ^= statealign & 63
     buf = ctypes.create_string_buffer(outlen)
-    sodium.crypto_generichash_final(state, buf, outlen)
+    sodium.crypto_generichash_final(statealign, buf, outlen)
     return buf.raw
 
 def randombytes(size):


### PR DESCRIPTION
The crypto_generichash state structure is defined with a 64 byte alignment in libsodium. With a ctypes string buffer you only get 16 byte alignment by default, so that should be realigned.
