### PR TITLE
Add support for converting secret key back to public key

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,5 @@ crypto_stream_xor(msg, cnt, nonce=None, key=None)
 crypt_sign_pk_to_box_pk(pk)
 
 crypto_sign_sk_to_box_sk(sk)
+
+crypto_sign_sk_to_pk(sk)

--- a/pysodium/__init__.py
+++ b/pysodium/__init__.py
@@ -48,6 +48,8 @@ crypto_sign_PUBLICKEYBYTES = sodium.crypto_sign_publickeybytes()
 crypto_sign_SECRETKEYBYTES = sodium.crypto_sign_secretkeybytes()
 crypto_sign_SEEDBYTES = sodium.crypto_sign_seedbytes()
 crypto_sign_BYTES = sodium.crypto_sign_bytes()
+crypto_sign_ed25519_SECRETKEYBYTES = sodium.crypto_sign_ed25519_secretkeybytes()
+crypto_sign_ed25519_PUBLICKEYBYTES = sodium.crypto_sign_ed25519_publickeybytes()
 crypto_stream_KEYBYTES = sodium.crypto_stream_keybytes()
 crypto_stream_NONCEBYTES = sodium.crypto_stream_noncebytes()
 crypto_generichash_BYTES = sodium.crypto_generichash_bytes()
@@ -398,3 +400,11 @@ def crypto_pwhash_scryptsalsa208sha256_str_verify(pwhash, password):
     if None in (pwhash, password):
         raise ValueError
     __check(sodium.crypto_pwhash_scryptsalsa208sha256_str_verify(pwhash, password, ctypes.c_ulonglong(len(password))))
+
+# int crypto_sign_ed25519_sk_to_pk(unsigned char *pk, const unsigned char *sk)
+def crypto_sign_sk_to_pk(sk):
+    if sk is None or len(sk) != crypto_sign_ed25519_SECRETKEYBYTES:
+        raise ValueError
+    res = ctypes.create_string_buffer(crypto_sign_ed25519_PUBLICKEYBYTES)
+    __check(sodium.crypto_sign_ed25519_sk_to_pk(ctypes.byref(res), sk))
+    return res.raw

--- a/test/test_pysodium.py
+++ b/test/test_pysodium.py
@@ -134,5 +134,10 @@ class TestPySodium(unittest.TestCase):
         with self.assertRaises(ValueError):
             pysodium.crypto_pwhash_scryptsalsa208sha256_str_verify(pwhash, 'wrongpassword')
 
+    def test_crypto_sign_sk_to_pk(self):
+        pk, sk = pysodium.crypto_sign_keypair()
+        pk2 = pysodium.crypto_sign_sk_to_pk(sk)
+        self.assertEqual(pk, pk2)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Consider...

```python
import pysodium as libnacl
class ED25519Identity(object):
    def __init__(self, pk = False, sk = False):
        if not sk:
            pk, sk = libnacl.crypto_sign_keypair()
        elif sk and not pk:
            pk = libnacl.crypto_sign_sk_to_pk(sk) # this PR adds this

        self.publickey = pk
        self.secretkey = sk
```

This very useful function was missing before.