### PR TITLE
wrap the crypto_box precomputation interfaces

### DIFF
--- a/pysodium/__init__.py
+++ b/pysodium/__init__.py
@@ -228,73 +228,33 @@ def crypto_box_beforenm(pk, sk):
     __check(sodium.crypto_box_beforenm(c, pk, sk))
     return c.raw
 
-# int crypto_box_easy(unsigned char *c, const unsigned char *m,
-#                        unsigned long long mlen, const unsigned char *n,
-#                        const unsigned char *pk, const unsigned char *sk);
-def crypto_box_easy(msg, nonce, pk, sk):
-    if None in (msg, nonce, pk, sk):
-        raise ValueError("invalid parameters")
-    c = ctypes.create_string_buffer(crypto_box_MACBYTES + len(msg))
-    __check(sodium.crypto_box_easy(c, msg.encode(), ctypes.c_ulonglong(len(msg)), nonce, pk, sk))
-    return c.raw
-
-def crypto_box_easy_afternm(msg, nonce, k):
-    if None in (msg, nonce, k):
-        raise ValueError("invalid parameters")
-    c = ctypes.create_string_buffer(crypto_box_MACBYTES + len(msg))
-    __check(sodium.crypto_box_easy_afternm(c, msg.encode(), ctypes.c_ulonglong(len(msg)), nonce, k))
-    return c.raw
-
-# int crypto_box_open_easy(unsigned char *m, const unsigned char *c,
-#                         unsigned long long clen, const unsigned char *n,
-#                         const unsigned char *pk, const unsigned char *sk);
-def crypto_box_open_easy(c, nonce, pk, sk):
-    if None in (c, nonce, pk, sk):
-        raise ValueError("invalid parameters")
-    msg = ctypes.create_string_buffer(len(c) - crypto_box_MACBYTES)
-    __check(sodium.crypto_box_open_easy(msg, c, ctypes.c_ulonglong(len(c)), nonce, pk, sk))
-    return msg.raw.decode()
-
-def crypto_box_open_easy_afternm(c, nonce, k):
-    if None in (c, nonce, k):
-        raise ValueError("invalid parameters")
-    msg = ctypes.create_string_buffer(len(c) - crypto_box_MACBYTES)
-    __check(sodium.crypto_box_open_easy_afternm(msg, c, ctypes.c_ulonglong(len(c)), nonce, k))
-    return msg.raw.decode()
-
 def crypto_box(msg, nonce, pk, sk):
     if None in (msg, nonce, pk, sk):
         raise ValueError("invalid parameters")
-    padded = b"\x00" * crypto_box_ZEROBYTES + msg
-    c = ctypes.create_string_buffer(len(padded))
-    __check(sodium.crypto_box(c, padded, ctypes.c_ulonglong(len(padded)), nonce, pk, sk))
-    return c.raw[crypto_box_BOXZEROBYTES:]
+    c = ctypes.create_string_buffer(crypto_box_MACBYTES + len(msg))
+    __check(sodium.crypto_box_easy(c, msg, ctypes.c_ulonglong(len(msg)), nonce, pk, sk))
+    return c.raw
 
 def crypto_box_afternm(msg, nonce, k):
     if None in (msg, nonce, k):
         raise ValueError("invalid parameters")
-    padded = b"\x00" * crypto_box_ZEROBYTES + msg
-    c = ctypes.create_string_buffer(len(padded))
-    __check(sodium.crypto_box_afternm(c, padded, ctypes.c_ulonglong(len(padded)), nonce, k))
-    return c.raw[crypto_box_BOXZEROBYTES:]
-
+    c = ctypes.create_string_buffer(crypto_box_MACBYTES + len(msg))
+    __check(sodium.crypto_box_easy_afternm(c, msg, ctypes.c_ulonglong(len(msg)), nonce, k))
+    return c.raw
 
 def crypto_box_open(c, nonce, pk, sk):
     if None in (c, nonce, pk, sk):
         raise ValueError("invalid parameters")
-    padded = b"\x00" * crypto_box_BOXZEROBYTES + c
-    msg = ctypes.create_string_buffer(len(padded))
-    __check(sodium.crypto_box_open(msg, padded, ctypes.c_ulonglong(len(padded)), nonce, pk, sk))
-    return msg.raw[crypto_box_ZEROBYTES:]
+    msg = ctypes.create_string_buffer(len(c) - crypto_box_MACBYTES)
+    __check(sodium.crypto_box_open_easy(msg, c, ctypes.c_ulonglong(len(c)), nonce, pk, sk))
+    return msg.raw
 
 def crypto_box_open_afternm(c, nonce, k):
     if None in (c, nonce, k):
         raise ValueError("invalid parameters")
-    padded = b"\x00" * crypto_box_BOXZEROBYTES + c
-    msg = ctypes.create_string_buffer(len(padded))
-    __check(sodium.crypto_box_open_afternm(msg, padded, ctypes.c_ulonglong(len(padded)), nonce, k))
-    return msg.raw[crypto_box_ZEROBYTES:]
-
+    msg = ctypes.create_string_buffer(len(c) - crypto_box_MACBYTES)
+    __check(sodium.crypto_box_open_easy_afternm(msg, c, ctypes.c_ulonglong(len(c)), nonce, k))
+    return msg.raw
 
 def crypto_secretbox(msg, nonce, k):
     if None in (msg, nonce, k):

--- a/pysodium/__init__.py
+++ b/pysodium/__init__.py
@@ -221,6 +221,13 @@ def crypto_box_seed_keypair(seed):
     __check(sodium.crypto_box_seed_keypair(pk, sk, seed))
     return pk.raw, sk.raw
 
+def crypto_box_beforenm(pk, sk):
+    if None in (pk, sk):
+        raise ValueError("invalid parameters")
+    c = ctypes.create_string_buffer(crypto_secretbox_KEYBYTES)
+    __check(sodium.crypto_box_beforenm(c, pk, sk))
+    return c.raw
+
 # int crypto_box_easy(unsigned char *c, const unsigned char *m,
 #                        unsigned long long mlen, const unsigned char *n,
 #                        const unsigned char *pk, const unsigned char *sk);
@@ -229,6 +236,13 @@ def crypto_box_easy(msg, nonce, pk, sk):
         raise ValueError("invalid parameters")
     c = ctypes.create_string_buffer(crypto_box_MACBYTES + len(msg))
     __check(sodium.crypto_box_easy(c, msg.encode(), ctypes.c_ulonglong(len(msg)), nonce, pk, sk))
+    return c.raw
+
+def crypto_box_easy_afternm(msg, nonce, k):
+    if None in (msg, nonce, k):
+        raise ValueError("invalid parameters")
+    c = ctypes.create_string_buffer(crypto_box_MACBYTES + len(msg))
+    __check(sodium.crypto_box_easy_afternm(c, msg.encode(), ctypes.c_ulonglong(len(msg)), nonce, k))
     return c.raw
 
 # int crypto_box_open_easy(unsigned char *m, const unsigned char *c,
@@ -241,12 +255,27 @@ def crypto_box_open_easy(c, nonce, pk, sk):
     __check(sodium.crypto_box_open_easy(msg, c, ctypes.c_ulonglong(len(c)), nonce, pk, sk))
     return msg.raw.decode()
 
+def crypto_box_open_easy_afternm(c, nonce, k):
+    if None in (c, nonce, k):
+        raise ValueError("invalid parameters")
+    msg = ctypes.create_string_buffer(len(c) - crypto_box_MACBYTES)
+    __check(sodium.crypto_box_open_easy_afternm(msg, c, ctypes.c_ulonglong(len(c)), nonce, k))
+    return msg.raw.decode()
+
 def crypto_box(msg, nonce, pk, sk):
     if None in (msg, nonce, pk, sk):
         raise ValueError("invalid parameters")
     padded = b"\x00" * crypto_box_ZEROBYTES + msg
     c = ctypes.create_string_buffer(len(padded))
     __check(sodium.crypto_box(c, padded, ctypes.c_ulonglong(len(padded)), nonce, pk, sk))
+    return c.raw[crypto_box_BOXZEROBYTES:]
+
+def crypto_box_afternm(msg, nonce, k):
+    if None in (msg, nonce, k):
+        raise ValueError("invalid parameters")
+    padded = b"\x00" * crypto_box_ZEROBYTES + msg
+    c = ctypes.create_string_buffer(len(padded))
+    __check(sodium.crypto_box_afternm(c, padded, ctypes.c_ulonglong(len(padded)), nonce, k))
     return c.raw[crypto_box_BOXZEROBYTES:]
 
 
@@ -256,6 +285,14 @@ def crypto_box_open(c, nonce, pk, sk):
     padded = b"\x00" * crypto_box_BOXZEROBYTES + c
     msg = ctypes.create_string_buffer(len(padded))
     __check(sodium.crypto_box_open(msg, padded, ctypes.c_ulonglong(len(padded)), nonce, pk, sk))
+    return msg.raw[crypto_box_ZEROBYTES:]
+
+def crypto_box_open_afternm(c, nonce, k):
+    if None in (c, nonce, k):
+        raise ValueError("invalid parameters")
+    padded = b"\x00" * crypto_box_BOXZEROBYTES + c
+    msg = ctypes.create_string_buffer(len(padded))
+    __check(sodium.crypto_box_open_afternm(msg, padded, ctypes.c_ulonglong(len(padded)), nonce, k))
     return msg.raw[crypto_box_ZEROBYTES:]
 
 

--- a/pysodium/__init__.py
+++ b/pysodium/__init__.py
@@ -222,7 +222,7 @@ def crypto_box_seed_keypair(seed):
     return pk.raw, sk.raw
 
 def crypto_box_beforenm(pk, sk):
-    if None in (pk, sk):
+    if pk is None or sk is None:
         raise ValueError("invalid parameters")
     c = ctypes.create_string_buffer(crypto_secretbox_KEYBYTES)
     __check(sodium.crypto_box_beforenm(c, pk, sk))

--- a/pysodium/__init__.py
+++ b/pysodium/__init__.py
@@ -317,7 +317,7 @@ def crypto_secretbox_open(c, nonce, k):
 #                    unsigned long long mlen, const unsigned char *pk);
 
 def crypto_box_seal(msg, k):
-    if None in (msg, k):
+    if msg is None or k is None:
         raise ValueError("invalid parameters")
     c = ctypes.create_string_buffer(len(msg)+crypto_box_SEALBYTES)
     __check(sodium.crypto_box_seal(c, msg, ctypes.c_ulonglong(len(msg)), k))
@@ -349,7 +349,7 @@ def crypto_sign_seed_keypair(seed):
 
 
 def crypto_sign(m, sk):
-    if None in (m, sk):
+    if m is None or sk is None:
         raise ValueError("invalid parameters")
     smsg = ctypes.create_string_buffer(len(m) + crypto_sign_BYTES)
     smsglen = ctypes.c_ulonglong()
@@ -358,7 +358,7 @@ def crypto_sign(m, sk):
 
 
 def crypto_sign_detached(m, sk):
-    if None in (m, sk):
+    if m is None or sk is None:
         raise ValueError("invalid parameters")
     sig = ctypes.create_string_buffer(crypto_sign_BYTES)
     # second parm is for output of signature len (optional, ignored if NULL)
@@ -367,7 +367,7 @@ def crypto_sign_detached(m, sk):
 
 
 def crypto_sign_open(sm, pk):
-    if None in (sm, pk):
+    if sm is None or pk is None:
         raise ValueError("invalid parameters")
     msg = ctypes.create_string_buffer(len(sm))
     msglen = ctypes.c_ulonglong()
@@ -452,7 +452,7 @@ def crypto_pwhash_scryptsalsa208sha256_str(passwd, opslimit, memlimit):
 #                                                  const char * const passwd,
 #                                                  unsigned long long passwdlen);
 def crypto_pwhash_scryptsalsa208sha256_str_verify(stored, passwd):
-    if None in (stored, passwd):
+    if stored is None or passwd is None:
        raise ValueError
     __check(sodium.crypto_pwhash_scryptsalsa208sha256_str_verify(stored, passwd, ctypes.c_ulonglong(len(passwd))))
 

--- a/test/test_pysodium.py
+++ b/test/test_pysodium.py
@@ -61,10 +61,31 @@ class TestPySodium(unittest.TestCase):
         self.assertEqual(pysodium.crypto_box_seal_open(c, pk, sk), b'howdy')
 
     def test_crypto_box_open(self):
+        m = b"howdy"
         pk, sk = pysodium.crypto_box_keypair()
         n = pysodium.randombytes(pysodium.crypto_box_NONCEBYTES)
-        c = pysodium.crypto_box(b"howdy", n, pk, sk)
-        pysodium.crypto_box_open(c, n, pk, sk)
+        c = pysodium.crypto_box(m, n, pk, sk)
+        plaintext = pysodium.crypto_box_open(c, n, pk, sk)
+        self.assertEqual(m, plaintext)
+
+        # Test the easy variants on the same message.
+        c_easy = pysodium.crypto_box_easy(m.decode(), n, pk, sk)
+        self.assertEqual(c, c_easy)
+        plaintext_easy = pysodium.crypto_box_open_easy(c, n, pk, sk)
+        self.assertEqual(m.decode(), plaintext_easy)
+
+        # Test the precomputation variants on the same message.
+        k = pysodium.crypto_box_beforenm(pk, sk)
+        c_precomp = pysodium.crypto_box_afternm(m, n, k)
+        self.assertEqual(c, c_precomp)
+        plaintext_precomp = pysodium.crypto_box_open_afternm(c, n, k)
+        self.assertEqual(m, plaintext_precomp)
+
+        # And finally the easy+precomputation variants.
+        c_precomp_easy = pysodium.crypto_box_easy_afternm(m.decode(), n, k)
+        self.assertEqual(c, c_precomp_easy)
+        plaintext_precomp_easy = pysodium.crypto_box_open_easy_afternm(c, n, k)
+        self.assertEqual(m.decode(), plaintext_precomp_easy)
 
     def test_crypto_secretbox_open(self):
         k = pysodium.randombytes(pysodium.crypto_secretbox_KEYBYTES)

--- a/test/test_pysodium.py
+++ b/test/test_pysodium.py
@@ -68,15 +68,6 @@ class TestPySodium(unittest.TestCase):
         plaintext = pysodium.crypto_box_open(c, n, pk, sk)
         self.assertEqual(m, plaintext)
 
-    def test_crypto_box_open_easy(self):
-        m = "howdy"
-        pk, sk = pysodium.crypto_box_keypair()
-        n = pysodium.randombytes(pysodium.crypto_box_NONCEBYTES)
-        c = pysodium.crypto_box_easy(m, n, pk, sk)
-        self.assertEqual(c, c)
-        plaintext = pysodium.crypto_box_open_easy(c, n, pk, sk)
-        self.assertEqual(m, plaintext)
-
     def test_crypto_box_open_afternm(self):
         m = b"howdy"
         pk, sk = pysodium.crypto_box_keypair()
@@ -85,16 +76,6 @@ class TestPySodium(unittest.TestCase):
         c = pysodium.crypto_box_afternm(m, n, k)
         self.assertEqual(c, c)
         plaintext = pysodium.crypto_box_open_afternm(c, n, k)
-        self.assertEqual(m, plaintext)
-
-    def test_crypto_box_open_easy_afternm(self):
-        m = "howdy"
-        pk, sk = pysodium.crypto_box_keypair()
-        k = pysodium.crypto_box_beforenm(pk, sk)
-        n = pysodium.randombytes(pysodium.crypto_box_NONCEBYTES)
-        c = pysodium.crypto_box_easy_afternm(m, n, k)
-        self.assertEqual(c, c)
-        plaintext = pysodium.crypto_box_open_easy_afternm(c, n, k)
         self.assertEqual(m, plaintext)
 
     def test_crypto_secretbox_open(self):
@@ -208,12 +189,12 @@ class TestPySodium(unittest.TestCase):
         self.assertEqual(pk, pk2)
 
     def test_AsymCrypto_With_Seeded_Keypair(self):
-        msg     = "correct horse battery staple"
+        msg     = b"correct horse battery staple"
         nonce   = pysodium.randombytes(pysodium.crypto_box_NONCEBYTES)
         pk, sk = pysodium.crypto_box_seed_keypair("howdy")
 
-        c = pysodium.crypto_box_easy(msg, nonce, pk, sk)
-        m = pysodium.crypto_box_open_easy(c, nonce, pk, sk)
+        c = pysodium.crypto_box(msg, nonce, pk, sk)
+        m = pysodium.crypto_box_open(c, nonce, pk, sk)
         
         self.assertEqual(msg, m)
 

--- a/test/test_pysodium.py
+++ b/test/test_pysodium.py
@@ -68,24 +68,34 @@ class TestPySodium(unittest.TestCase):
         plaintext = pysodium.crypto_box_open(c, n, pk, sk)
         self.assertEqual(m, plaintext)
 
-        # Test the easy variants on the same message.
-        c_easy = pysodium.crypto_box_easy(m.decode(), n, pk, sk)
-        self.assertEqual(c, c_easy)
-        plaintext_easy = pysodium.crypto_box_open_easy(c, n, pk, sk)
-        self.assertEqual(m.decode(), plaintext_easy)
+    def test_crypto_box_open_easy(self):
+        m = "howdy"
+        pk, sk = pysodium.crypto_box_keypair()
+        n = pysodium.randombytes(pysodium.crypto_box_NONCEBYTES)
+        c = pysodium.crypto_box_easy(m, n, pk, sk)
+        self.assertEqual(c, c)
+        plaintext = pysodium.crypto_box_open_easy(c, n, pk, sk)
+        self.assertEqual(m, plaintext)
 
-        # Test the precomputation variants on the same message.
+    def test_crypto_box_open_afternm(self):
+        m = b"howdy"
+        pk, sk = pysodium.crypto_box_keypair()
         k = pysodium.crypto_box_beforenm(pk, sk)
-        c_precomp = pysodium.crypto_box_afternm(m, n, k)
-        self.assertEqual(c, c_precomp)
-        plaintext_precomp = pysodium.crypto_box_open_afternm(c, n, k)
-        self.assertEqual(m, plaintext_precomp)
+        n = pysodium.randombytes(pysodium.crypto_box_NONCEBYTES)
+        c = pysodium.crypto_box_afternm(m, n, k)
+        self.assertEqual(c, c)
+        plaintext = pysodium.crypto_box_open_afternm(c, n, k)
+        self.assertEqual(m, plaintext)
 
-        # And finally the easy+precomputation variants.
-        c_precomp_easy = pysodium.crypto_box_easy_afternm(m.decode(), n, k)
-        self.assertEqual(c, c_precomp_easy)
-        plaintext_precomp_easy = pysodium.crypto_box_open_easy_afternm(c, n, k)
-        self.assertEqual(m.decode(), plaintext_precomp_easy)
+    def test_crypto_box_open_easy_afternm(self):
+        m = "howdy"
+        pk, sk = pysodium.crypto_box_keypair()
+        k = pysodium.crypto_box_beforenm(pk, sk)
+        n = pysodium.randombytes(pysodium.crypto_box_NONCEBYTES)
+        c = pysodium.crypto_box_easy_afternm(m, n, k)
+        self.assertEqual(c, c)
+        plaintext = pysodium.crypto_box_open_easy_afternm(c, n, k)
+        self.assertEqual(m, plaintext)
 
     def test_crypto_secretbox_open(self):
         k = pysodium.randombytes(pysodium.crypto_secretbox_KEYBYTES)


### PR DESCRIPTION
Fixes https://github.com/stef/pysodium/issues/33.

Looking at this code, it's not clear to me that pysodium needs to expose both `crypto_box` and `crypto_box_easy`. Our `crypto_box` wrapper already handles padding, so to a Python caller there's not really a difference between the two functions. It looks like you chose to make the `_easy` variants deal with strings instead of bytes, but I think for that kind of change it would be a better idea to expose an entirely new function with a different name.