### PR TITLE
Add LibSodium version string to wrapper

### DIFF
--- a/pysodium/__init__.py
+++ b/pysodium/__init__.py
@@ -32,6 +32,7 @@ import ctypes.util
 
 sodium = ctypes.cdll.LoadLibrary(ctypes.util.find_library('sodium') or ctypes.util.find_library('libsodium'))
 sodium.crypto_pwhash_scryptsalsa208sha256_strprefix.restype = ctypes.c_char_p
+sodium.sodium_version_string.restype = ctypes.c_char_p
 crypto_box_NONCEBYTES = sodium.crypto_box_noncebytes()
 crypto_box_PUBLICKEYBYTES = sodium.crypto_box_publickeybytes()
 crypto_box_SECRETKEYBYTES = sodium.crypto_box_secretkeybytes()


### PR DESCRIPTION
Currently "pysodium.sodium.sodium_version_string()" returns only the pointer, not the actual character string, such as "1.0.9".