### PR TITLE
Remove .decode() from crypto_box_open_easy

### DIFF
--- a/pysodium/__init__.py
+++ b/pysodium/__init__.py
@@ -229,7 +229,7 @@ def crypto_box_easy(msg, nonce, pk, sk):
     if None in (msg, nonce, pk, sk):
         raise ValueError("invalid parameters")
     c = ctypes.create_string_buffer(crypto_box_MACBYTES + len(msg))
-    __check(sodium.crypto_box_easy(c, msg.encode(), ctypes.c_ulonglong(len(msg)), nonce, pk, sk))
+    __check(sodium.crypto_box_easy(c, msg, ctypes.c_ulonglong(len(msg)), nonce, pk, sk))
     return c.raw
 
 # int crypto_box_open_easy(unsigned char *m, const unsigned char *c,
@@ -240,7 +240,7 @@ def crypto_box_open_easy(c, nonce, pk, sk):
         raise ValueError("invalid parameters")
     msg = ctypes.create_string_buffer(len(c) - crypto_box_MACBYTES)
     __check(sodium.crypto_box_open_easy(msg, c, ctypes.c_ulonglong(len(c)), nonce, pk, sk))
-    return msg.raw.decode()
+    return msg.raw
 
 def crypto_box(msg, nonce, pk, sk):
     if None in (msg, nonce, pk, sk):

--- a/test/test_pysodium.py
+++ b/test/test_pysodium.py
@@ -177,7 +177,7 @@ class TestPySodium(unittest.TestCase):
         self.assertEqual(pk, pk2)
 
     def test_AsymCrypto_With_Seeded_Keypair(self):
-        msg     = "correct horse battery staple"
+        msg     = b"correct horse battery staple"
         nonce   = pysodium.randombytes(pysodium.crypto_box_NONCEBYTES)
         pk, sk = pysodium.crypto_box_seed_keypair("howdy")
 


### PR DESCRIPTION
The returned message is not necessarily utf-8 (or text at all) so the function shouldn't decode it as such.
Also remove the .encode from crypto_box_easy, and change the test to process binary data.