### PR TITLE
Added chachapoly _detached; added test; updated README, AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,3 +13,4 @@ Andreas Bogk
 Fredrick Brennan
 iachievedit
 Tacitus Aedifex
+venzen

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Constants:
 
 crypto_aead_chacha20poly1305_KEYBYTES, crypto_aead_chacha20poly1305_NONCEBYTES
 crypto_aead_chacha20poly1305_ietf_KEYBYTES, crypto_aead_chacha20poly1305_ietf_NONCEBYTES
+crypto_aead_chacha20poly1305_ABYTES,
 crypto_auth_KEYBYTES, crypto_auth_BYTES,
 crypto_box_NONCEBYTES, crypto_box_PUBLICKEYBYTES,
 crypto_box_SECRETKEYBYTES, crypto_box_ZEROBYTES,
@@ -55,6 +56,10 @@ crypto_auth(tag, message, key)
 crypto_aead_chacha20poly1305_encrypt(message, ad, nonce, key)
 
 crypto_aead_chacha20poly1305_decrypt(ciphertext, ad, nonce, key)
+
+crypto_aead_chacha20poly1305_encrypt_detached(message, ad, nonce, key)
+
+crypto_aead_chacha20poly1305_decrypt_detached(ciphertext, mac, ad, nonce, key)
 
 crypto_aead_chacha20poly1305_ietf_encrypt(message, ad, nonce, key)
 

--- a/test/test_pysodium.py
+++ b/test/test_pysodium.py
@@ -124,6 +124,17 @@ class TestPySodium(unittest.TestCase):
         self.assertEqual(binascii.unhexlify(b"e3e446f7ede9a19b62a4677dabf4e3d24b876bb284753896e1d6"), output)
         output = pysodium.crypto_aead_chacha20poly1305_decrypt(output, ad, nonce, key)
         self.assertEqual(output, input_)
+        
+    def test_aead_chacha20poly1305_detached(self):
+        key = binascii.unhexlify(b"4290bcb154173531f314af57f3be3b5006da371ece272afa1b5dbdd1100a1007")
+        input_ = binascii.unhexlify(b"86d09974840bded2a5ca")
+        nonce = binascii.unhexlify(b"cd7cf67be39c794a")
+        ad = binascii.unhexlify(b"87e229d4500845a079c0")
+        output, mac = pysodium.crypto_aead_chacha20poly1305_encrypt_detached(input_, ad, nonce, key)
+        self.assertEqual(binascii.unhexlify(b"e3e446f7ede9a19b62a4"), output)
+        self.assertEqual(binascii.unhexlify(b"677dabf4e3d24b876bb284753896e1d6"), mac)
+        output = pysodium.crypto_aead_chacha20poly1305_decrypt_detached(output, mac, ad, nonce, key)
+        self.assertEqual(output, input_)
 
     def test_aead_chacha20poly1305_ietf(self):
         if not pysodium.sodium_version_check(1, 0, 4): return


### PR DESCRIPTION
Added wrapper functions for chacha20poly1305 *_detached* encrypt/decrypt functions in libsodium that allow for a detached MAC tag.

functions:
```
crypto_aead_chacha20poly1305_encrypt_detached(message, ad, nonce, key)
```
and
```
crypto_aead_chacha20poly1305_decrypt_detached(ciphertext, mac, ad, nonce, key)
```

Tested and works. 

Included additions in README, updated test file, and added my name to AUTHORS