### PR TITLE
Add pysodium.crypto_stream_chacha20_xor_ic

### DIFF
--- a/pysodium/__init__.py
+++ b/pysodium/__init__.py
@@ -301,6 +301,19 @@ def crypto_stream_chacha20_xor(message, nonce, key):
 
     return c.raw
 
+# crypto_stream_chacha20_xor_ic(unsigned char *c, const unsigned char *m, unsigned long long mlen, const unsigned char *n, uint64_t ic, const unsigned char *k)
+def crypto_stream_chacha20_xor_ic(message, nonce, initial_counter, key):
+    if len(nonce) != crypto_stream_chacha20_NONCEBYTES: raise ValueError("truncated nonce")
+    if len(key) != crypto_stream_chacha20_KEYBYTES: raise ValueError("truncated key")
+
+    mlen = ctypes.c_longlong(len(message))
+    ic = ctypes.c_uint64(initial_counter)
+
+    c = ctypes.create_string_buffer(len(message))
+
+    __check(sodium.crypto_stream_chacha20_xor_ic(c, message, mlen, nonce, ic, key))
+
+    return c.raw
 
 # crypto_aead_chacha20poly1305_encrypt(unsigned char *c, unsigned long long *clen, const unsigned char *m, unsigned long long mlen, const unsigned char *ad, unsigned long long adlen, const unsigned char *nsec, const unsigned char *npub, const unsigned char *k);
 def crypto_aead_chacha20poly1305_encrypt(message, ad, nonce, key):

--- a/test/test_pysodium.py
+++ b/test/test_pysodium.py
@@ -27,9 +27,9 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
-import pysodium
 import unittest
 import binascii
+import pysodium
 
 
 class TestPySodium(unittest.TestCase):
@@ -335,6 +335,14 @@ class TestPySodium(unittest.TestCase):
         output = pysodium.crypto_stream_chacha20_xor(input_, nonce, key)
         self.assertEqual(binascii.unhexlify(b"f798a189f195e66982105ffb640bb7757f579da31602fc93ec01ac56f85ac3c134a4547b733b46413042c9440049176905d3be59ea1c53f15916155c2be8241a38008b9a26bc35941e2444177c8ade6689de95264986d95889fb60e84629c9bd9a5acb1cc118be563eb9b3a4a472f82e09a7e778492b562ef7130e88dfe031c79db9d4f7c7a899151b9a475032b63fc385245fe054e3dd5a97a5f576fe064025d3ce042c566ab2c507b138db853e3d6959660996546cc9c4a6eafdc777c040d70eaf46f76dad3979e5c5360c3317166a1c894c94a371876a94df7628fe4eaaf2ccb27d5aaae0ad7ad0f9d4b6ad3b54098746d4524d38407a6deb3ab78fab78c9"),
                          output)
+
+    def test_crypto_stream_chacha20_xor_ic(self):
+        key = binascii.unhexlify(b"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")
+        nonce = binascii.unhexlify(b"0001020304050607")
+        input_ = b'\x00' * 128
+        ic = 2
+        output = pysodium.crypto_stream_chacha20_xor_ic(input_, nonce, ic, key)
+        self.assertEqual(binascii.unhexlify(b"9db9d4f7c7a899151b9a475032b63fc385245fe054e3dd5a97a5f576fe064025d3ce042c566ab2c507b138db853e3d6959660996546cc9c4a6eafdc777c040d70eaf46f76dad3979e5c5360c3317166a1c894c94a371876a94df7628fe4eaaf2ccb27d5aaae0ad7ad0f9d4b6ad3b54098746d4524d38407a6deb3ab78fab78c9"), output)
 
     def test_crypto_blake2b(self):
         message   = binascii.unhexlify(b'54686520717569636b2062726f776e20666f78206a756d7073206f76657220746865206c617a7920646f67')


### PR DESCRIPTION
Hi,

Please accept this pull request. I'm using pysodium, and I need this primitive for one of my projects. I've tested it; it works.

Commit message:

This primitive allows one to arbitrarily seek an offset into a
chacha20 stream; one of the most important features of the salsa20 and
chacha20 family of stream ciphers.