### PR TITLE
Add LICENSE.txt to sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
-include README.md
 include AUTHORS
+include LICENSE.txt
+include README.md


### PR DESCRIPTION
While I'm here, sort MANIFEST.in

We (FreeBSD ports) use the sdist from PyPI. It'll be great if it contains a license file.