### PR TITLE
Fix for pip install of dist tar

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,10 @@ from setuptools import setup, find_packages
 # README file and 2) it's easier to type in the README file than to put a raw
 # string in below ...
 def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+    try:
+        return open(os.path.join(os.path.dirname(__file__), fname)).read()
+    except FileNotFoundError:
+        return ""
 
 setup(
     name="pysodium",


### PR DESCRIPTION
Running `pip install --no-deps file:///home/username/pysodium-0.7.5.linux-x86_64.tar.gz` fails, because the `README.md` is not included in the tar.

This is also the method that Poetry uses, hence you can’t add pysodium to a project using Poetry.

This small fix simply ignores `FileNotFoundError`.