### PR TITLE
Fix error on ristretto255 functions that return void and add a new non-intelligent test

### DIFF
--- a/pysodium/__init__.py
+++ b/pysodium/__init__.py
@@ -1135,7 +1135,7 @@ def crypto_hash_sha512_init():
 def crypto_hash_sha512_update(state, data):
     __check(sodium.crypto_hash_sha512_update(state,data,ctypes.c_ulonglong(len(data))))
     return state
-    
+
 # int crypto_hash_sha512_final(crypto_hash_sha512_state *state, unsigned char *out)
 def crypto_hash_sha512_final(state):
     out = ctypes.create_string_buffer(crypto_hash_sha512_BYTES)
@@ -1191,7 +1191,7 @@ def crypto_kx_server_session_keys(server_pk, server_sk, client_pk):
 @sodium_version(1, 0, 4)
 def sodium_increment(n):
     sodium.sodium_increment(n, ctypes.c_size_t(len(n)))
-     
+
 
 # int crypto_core_ristretto255_is_valid_point(const unsigned char *p);
 @sodium_version(1, 0, 18)
@@ -1272,7 +1272,7 @@ def crypto_core_ristretto255_sub(p,q):
 @sodium_version(1, 0, 18)
 def crypto_core_ristretto255_random():
     p = ctypes.create_string_buffer(crypto_core_ristretto255_BYTES)
-    __check(sodium.crypto_core_ristretto255_random(p))
+    sodium.crypto_core_ristretto255_random(p)
     return p.raw
 
 # void crypto_core_ristretto255_scalar_negate(unsigned char *neg, const unsigned char *s)
@@ -1280,7 +1280,7 @@ def crypto_core_ristretto255_random():
 def crypto_core_ristretto255_scalar_negate(s):
     if not s or len(s)!=crypto_core_ristretto255_SCALARBYTES: raise ValueError("Invalid param, must be {} bytes".format(crypto_core_ristretto255_SCALARBYTES))
     r = ctypes.create_string_buffer(crypto_core_ristretto255_SCALARBYTES)
-    __check(sodium.crypto_core_ristretto255_scalar_negate(r,s))
+    sodium.crypto_core_ristretto255_scalar_negate(r,s)
     return r.raw
 
 # void crypto_core_ristretto255_scalar_complement(unsigned char *comp, const unsigned char *s)
@@ -1288,7 +1288,7 @@ def crypto_core_ristretto255_scalar_negate(s):
 def crypto_core_ristretto255_scalar_complement(s):
     if not s or len(s)!=crypto_core_ristretto255_SCALARBYTES: raise ValueError("Invalid param, must be {} bytes".format(crypto_core_ristretto255_SCALARBYTES))
     r = ctypes.create_string_buffer(crypto_core_ristretto255_SCALARBYTES)
-    __check(sodium.crypto_core_ristretto255_scalar_complement(r,s))
+    sodium.crypto_core_ristretto255_scalar_complement(r,s)
     return r.raw
 
 # void crypto_core_ristretto255_scalar_add(unsigned char *z, const unsigned char *x, const unsigned char *y)
@@ -1297,7 +1297,7 @@ def crypto_core_ristretto255_scalar_add(x,y):
     if not x or len(x)!=crypto_core_ristretto255_SCALARBYTES: raise ValueError("Invalid param, must be {} bytes".format(crypto_core_ristretto255_SCALARBYTES))
     if not y or len(y)!=crypto_core_ristretto255_SCALARBYTES: raise ValueError("Invalid param, must be {} bytes".format(crypto_core_ristretto255_SCALARBYTES))
     r = ctypes.create_string_buffer(crypto_core_ristretto255_SCALARBYTES)
-    __check(sodium.crypto_core_ristretto255_scalar_add(r,x,y))
+    sodium.crypto_core_ristretto255_scalar_add(r,x,y)
     return r.raw
 
 # void crypto_core_ristretto255_scalar_sub(unsigned char *z, const unsigned char *x, const unsigned char *y)
@@ -1306,7 +1306,7 @@ def crypto_core_ristretto255_scalar_sub(x,y):
     if not x or len(x)!=crypto_core_ristretto255_SCALARBYTES: raise ValueError("Invalid param, must be {} bytes".format(crypto_core_ristretto255_SCALARBYTES))
     if not y or len(y)!=crypto_core_ristretto255_SCALARBYTES: raise ValueError("Invalid param, must be {} bytes".format(crypto_core_ristretto255_SCALARBYTES))
     r = ctypes.create_string_buffer(crypto_core_ristretto255_SCALARBYTES)
-    __check(sodium.crypto_core_ristretto255_scalar_sub(r,x,y))
+    sodium.crypto_core_ristretto255_scalar_sub(r,x,y)
     return r.raw
 
 # void crypto_core_ristretto255_scalar_mul(unsigned char *z, const unsigned char *x, const unsigned char *y)

--- a/test/test_pysodium.py
+++ b/test/test_pysodium.py
@@ -539,6 +539,13 @@ class TestPySodium(unittest.TestCase):
         # stupid check that random returns different values...
         self.assertNotEqual(a,b)
 
+    def test_crypto_core_ristretto255_random(self):
+        if not pysodium.sodium_version_check(1, 0, 18): return
+        a = pysodium.crypto_core_ristretto255_random()
+        b = pysodium.crypto_core_ristretto255_random()
+        # same stupid check that random returns different values...
+        self.assertNotEqual(a,b)
+
     def test_crypto_core_ristretto255_is_valid_point(self):
         if not pysodium.sodium_version_check(1, 0, 18): return
         invalid = binascii.unhexlify(b"ecffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f")


### PR DESCRIPTION
Hi @stef,

I was taking a look at your libsodium wrapper and while testing ristretto255 functionality I came across a couple of small bugs that were using `__check` function for `void` returns from libsodium.

Added a new test and realized that some of the other ristretto255 tests weren't passing for the same reason and fix those as well.

Cheers

Juan Elosua